### PR TITLE
Add missing Time::Piece prereq to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,3 +20,4 @@ repository.type = git
 [Prereqs]
 Mojolicious = 5.67
 Mojolicious::Plugin::FormFieldsFromJSON = 0.19
+Time::Piece = 0


### PR DESCRIPTION
This change resolves the `prereq_matches_use` [CPANTS issue](https://cpants.cpanauthors.org/dist/Mojolicious-Plugin-FormFieldsFromJSON-Date).