### PR TITLE
Reduce Perls on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ perl:
     - "5.18"
     - "5.16"
     - "5.14"
-    - "5.12"
-    - "5.10"
 
 install:
     - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }


### PR DESCRIPTION
... since Dist::Zilla requires at least Perl 5.14.